### PR TITLE
Make intializer compatible with `zeitwerk`.

### DIFF
--- a/lib/scrivito_advanced_editors/engine.rb
+++ b/lib/scrivito_advanced_editors/engine.rb
@@ -5,7 +5,9 @@ module ScrivitoAdvancedEditors
     isolate_namespace ScrivitoAdvancedEditors
 
     initializer "scrivito_editors.scrivito_advanced_tag_helper" do
-      ActionView::Base.send :include, ScrivitoAdvancedTagHelper
+      config.after_initialize do
+        ActionView::Base.send :include, ScrivitoAdvancedTagHelper
+      end
     end
   end
 end


### PR DESCRIPTION
This should make the gem compatible with rails 7.

I _think_ this is also backwards compatible, but I am not 100% sure how far.

It would be awesome to have another gem release that works with rails 7 (with or without this patch).

Thanks a lot!